### PR TITLE
settings: Fix fallback avatars for image uploaders.

### DIFF
--- a/web/src/realm_icon.ts
+++ b/web/src/realm_icon.ts
@@ -36,7 +36,7 @@ export function build_realm_icon_widget(upload_function: UploadFunction): void {
 }
 
 export function rerender(): void {
-    $("#realm-icon-upload-widget .image-block").attr("src", realm.realm_icon_url);
+    $("#realm-icon-upload-widget .image-block-image").attr("src", realm.realm_icon_url);
     if (realm.realm_icon_source === "U") {
         $("#realm-icon-upload-widget .image-delete-button").show();
     } else {

--- a/web/src/realm_logo.ts
+++ b/web/src/realm_logo.ts
@@ -75,7 +75,7 @@ export function render(): void {
     const $night_file_input = $<HTMLInputElement>(
         "#realm-night-logo-upload-widget input.image_file_input",
     );
-    $("#realm-day-logo-upload-widget .image-block").attr("src", realm.realm_logo_url);
+    $("#realm-day-logo-upload-widget .image-block-image").attr("src", realm.realm_logo_url);
 
     if (realm.realm_night_logo_source === "D" && realm.realm_logo_source !== "D") {
         // If no dark theme logo is uploaded but a light theme one
@@ -83,9 +83,12 @@ export function render(): void {
         // of transparent background logos that look good on both
         // dark and light themes.  See also similar code in admin.ts.
 
-        $("#realm-night-logo-upload-widget .image-block").attr("src", realm.realm_logo_url);
+        $("#realm-night-logo-upload-widget .image-block-image").attr("src", realm.realm_logo_url);
     } else {
-        $("#realm-night-logo-upload-widget .image-block").attr("src", realm.realm_night_logo_url);
+        $("#realm-night-logo-upload-widget .image-block-image").attr(
+            "src",
+            realm.realm_night_logo_url,
+        );
     }
 
     const $realm_logo = $<HTMLImageElement>("#realm-navbar-wide-logo");

--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -97,6 +97,9 @@ function display_avatar_upload_complete(): void {
     $("#user-avatar-upload-widget .upload-spinner-background").css({visibility: "hidden"});
     $("#user-avatar-upload-widget .image-upload-text").show();
     $("#user-avatar-upload-widget .image-delete-button").show();
+
+    ui_util.restore_ublockorigin_hidden_img($("#user-avatar-upload-widget .image-block-image"));
+    ui_util.restore_ublockorigin_hidden_img($("#personal-menu .header-button-avatar-image"));
 }
 
 function display_avatar_upload_started(): void {

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -45,6 +45,7 @@ import * as timerender from "./timerender.ts";
 import {group_setting_value_schema} from "./types.ts";
 import type {HTMLSelectOneElement} from "./types.ts";
 import * as ui_report from "./ui_report.ts";
+import * as ui_util from "./ui_util.ts";
 import * as user_groups from "./user_groups.ts";
 import type {UserGroup} from "./user_groups.ts";
 import * as util from "./util.ts";
@@ -1465,6 +1466,8 @@ export function build_page(): void {
         $spinner.css({visibility: "hidden"});
         $upload_text.show();
         $delete_button.show();
+
+        ui_util.restore_ublockorigin_hidden_img($("#realm-icon-upload-widget .image-block-image"));
     }
 
     function realm_icon_logo_upload_start(

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -300,3 +300,68 @@ export function enable_element_and_remove_tooltip($element: JQuery): void {
     }
     $element.unwrap(".disabled-tooltip");
 }
+
+export function restore_ublockorigin_hidden_img($img: JQuery): void {
+    /* Use this function on any visble `img` elements that may have just been
+       changed from a gravatar URL to a non-gravatar URL. It will make sure
+       that it is still visible to users of uBlock Origin on Firefox who block
+       gravatar.
+
+       * `$img` should correspond to a single `img` tag.
+
+       Some details:
+
+       If the user blocks gravatar with uBlock Origin, it will hide any img
+       element, such as an avatar or realm icon, which has a gravatar URL in
+       the src. If the user then uploads a new image to replace the gravatar
+       image, the src of the relevant img element(s) will be set to the new
+       non-gravatar URL. The problem is that the img element(s) will not
+       simply reappear (without a page reload).
+
+       uBlock Origin seems to activate the hiding of the element using a
+       randomized attribute. It seems that removing this attribute is the
+       only way to make the element visible again.
+
+       We make sure the element is invisible, try to find an unexpected tag
+       set to an empty value, and remove it. We assume that Zulip itself has
+       no reason to hide the img. */
+
+    // Anticipating attributes we might put on an img element. If we add
+    // other attributes to any img tags that get passed into here, we will
+    // need to add them here.
+    const expectedAttrs = new Set(["class", "src"]);
+
+    $img.filter(":hidden").each((_, img) => {
+        let uBlockOriginAttr: string | null = null;
+
+        for (const attr of img.attributes) {
+            // Normal attributes are not of interest.
+            if (expectedAttrs.has(attr.name)) {
+                continue;
+            }
+
+            // If we already found an abnormal attribute, we don't expect
+            // more. We don't know what's going on so let's not risk
+            // continuing.
+            if (uBlockOriginAttr !== null) {
+                return;
+            }
+
+            // Abnormal attributes that are not set to empty string are not
+            // what we expect. We don't know what's going on so let's not
+            // risk continuing.
+            if (attr.value !== "") {
+                return;
+            }
+
+            uBlockOriginAttr = attr.name;
+        }
+
+        // We didn't find a uBlock Origin attribute
+        if (uBlockOriginAttr === null) {
+            return;
+        }
+
+        img.removeAttribute(uBlockOriginAttr);
+    });
+}

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -150,7 +150,7 @@ export const update_person = function update(event: UserUpdate): void {
             current_user.avatar_source = event.avatar_source;
             current_user.avatar_url = url;
             current_user.avatar_url_medium = event.avatar_url_medium;
-            $("#user-avatar-upload-widget .image-block").attr("src", event.avatar_url_medium);
+            $("#user-avatar-upload-widget .image-block-image").attr("src", event.avatar_url_medium);
             $("#personal-menu .header-button-avatar-image").attr(
                 "src",
                 `${event.avatar_url_medium}`,

--- a/web/styles/image_upload_widget.css
+++ b/web/styles/image_upload_widget.css
@@ -8,6 +8,12 @@
     .image-block {
         background-size: contain;
         height: 100%;
+
+        img {
+            /* TODO - I'm not sure why this is necessary for the
+               realm icon but not the avatar */
+            height: 100%;
+        }
     }
 
     .image-hover-background {
@@ -150,6 +156,7 @@
 /* CSS related to settings page user avatar upload widget only */
 #user-avatar-upload-widget {
     .image-block {
+        background-color: var(--color-background-image-loader);
         width: 200px;
         height: 200px;
     }
@@ -170,6 +177,10 @@
     .image-delete-button {
         top: 5px;
         right: 5px;
+    }
+
+    .image-block {
+        background-color: var(--color-background-image-loader);
     }
 }
 

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -56,6 +56,8 @@
             <div id="personal-menu" class="hidden-for-spectators navbar-item">
                 <a class="header-button tippy-zulip-delayed-tooltip" tabindex="0" role="button" data-tooltip-template-id="personal-menu-tooltip-template">
                     <div class="header-button-avatar">
+                        <!-- If you add attributes to this img tag, update the list of
+                        expected tags in ui_util.restore_ublockorigin_hidden_img. -->
                         <img class="header-button-avatar-image" src="{{user_avatar}}"/>
                     </div>
                 </a>

--- a/web/templates/settings/image_upload_widget.hbs
+++ b/web/templates/settings/image_upload_widget.hbs
@@ -22,7 +22,11 @@
             <img class="image_upload_spinner" src="../../images/loading/tail-spin.svg" alt="" />
         </span>
     </div>
-    <img class="image-block" src="{{ image }}"/>
+    <div class="image-block">
+        <!-- If you add attributes to this img tag, update the list of
+        expected tags in ui_util.restore_ublockorigin_hidden_img. -->
+        <img class="image-block-image" src="{{ image }}"/>
+    </div>
     <input type="file" name="file_input" class="notvisible image_file_input"  value="{{ upload_text }}" />
     <div class="image_file_input_error text-error"></div>
 </div>

--- a/web/tests/ui_util.test.cjs
+++ b/web/tests/ui_util.test.cjs
@@ -79,3 +79,109 @@ run_test("replace_emoji_name_with_emoji_unicode", () => {
     const man_cook_emoji = "👨‍🍳";
     assert.equal(man_cook_emoji, ui_util.convert_emoji_element_to_unicode($emoji));
 });
+
+run_test("ublockorigin_hidden_img_restored", () => {
+    // This needs to stub out so much that zjquery doesn't have, we just
+    // make it from scratch.
+
+    const ublockorigin_attr = "xzotehdedxqo";
+
+    let filter_called;
+    let remove_attribute_called;
+    let $img;
+
+    const make_img = (attributes) => {
+        const img_element = {
+            // `<element>.attributes` is a NamedNodeMap, but we can't create one here.
+            // However we just need to iterate over it, so we can simulate it with an array.
+            attributes,
+            removeAttribute(attr) {
+                remove_attribute_called = true;
+                assert.equal(attr, ublockorigin_attr);
+            },
+        };
+
+        const $i = {
+            filter(param) {
+                filter_called = true;
+                assert.equal(param, ":hidden");
+                return $img;
+            },
+            each(f) {
+                f(0, img_element);
+            },
+        };
+
+        return $i;
+    };
+
+    // Case 0:
+    // uBlock Origin attribute present and removed
+
+    filter_called = false;
+    remove_attribute_called = false;
+
+    $img = make_img([
+        {name: "class", value: "img"},
+        {name: "id", value: "the-img"},
+        {name: "src", value: "/not-gravatar.png"},
+        {name: ublockorigin_attr, value: ""},
+    ]);
+    ui_util.restore_ublockorigin_hidden_img($img);
+
+    assert.ok(filter_called);
+    assert.ok(remove_attribute_called);
+
+    // Case 1:
+    // No uBlock Origin attribute, no attributes removed.
+
+    filter_called = false;
+    remove_attribute_called = false;
+
+    $img = make_img([
+        {name: "class", value: "img"},
+        {name: "id", value: "the-img"},
+        {name: "src", value: "/not-gravatar.png"},
+    ]);
+    ui_util.restore_ublockorigin_hidden_img($img);
+
+    assert.ok(filter_called);
+    assert.ok(!remove_attribute_called);
+
+    // Case 2:
+    // uBlock Origin attribute present but not empty. No
+    // attributes removed.
+
+    filter_called = false;
+    remove_attribute_called = false;
+
+    $img = make_img([
+        {name: "class", value: "img"},
+        {name: "id", value: "the-img"},
+        {name: ublockorigin_attr, value: "oops"},
+        {name: "src", value: "/not-gravatar.png"},
+    ]);
+    ui_util.restore_ublockorigin_hidden_img($img);
+
+    assert.ok(filter_called);
+    assert.ok(!remove_attribute_called);
+
+    // Case 3:
+    // uBlock Origin attribute present along with another
+    // mystery attribute. No attributes removed.
+
+    filter_called = false;
+    remove_attribute_called = false;
+
+    $img = make_img([
+        {name: "class", value: "img"},
+        {name: "id", value: "the-img"},
+        {name: "src", value: "/not-gravatar.png"},
+        {name: ublockorigin_attr, value: ""},
+        {name: "mysteryattribute", value: ""},
+    ]);
+    ui_util.restore_ublockorigin_hidden_img($img);
+
+    assert.ok(filter_called);
+    assert.ok(!remove_attribute_called);
+});


### PR DESCRIPTION
(This is a placeholder. Note that the base is not `main`. It's based on another PR that is still being removed. Once it's merged, I will submit this in earnest. Though, I may try to get reviews on this in the mean time.)

---

Fixes part of https://github.com/zulip/zulip/issues/19123: Gracefully block gravatar for Avatar and Realm Icon uploaders. (There is still at least one more PR to make for this issue after this.)

This issue was initially reported for the avatar uploader widget being broken when using uBlock Origin to block gravatar. I fix that here, along with the realm icon uploader. However, the scope was expanded in the discussion to include all similar outcomes of blocking the gravatar domain, which is why it only fixes part of the reported issue.

Similar to what I did in #34370, I created a surrounding `div` element and moved the css attributes to it from from the `img`. I then added grey background (as `timabbot` suggested). Though both the avatar uploader and the realm icon uploader use the same widget, only the avatar uploader was collapsed and unusable when using uBlock Origin. The realm icon uploader just had a darker color.

Additionally, there was a bug if a user tries to replace a gravatar image with a custom image while blocking gravatar. The uploaded image wouldn't show up until the user reloaded the page. The reason is that uBlock Origin actually hides `img` elements for images that it blocks, using a randomized attribute to indicate that it should be hidden. When the user uploads their replacement image and we set the `src` of the hidden `img` element, the element doesn't reappear because the randomized attribute is still there. So I made a function to strip it away.

# Results

There seem to be three modes for the avatars:

* working correctly
* browser-specific broken image icon
* image removed by (I presume) uBlock Origin

I took some screenshots in Firefox and Chromium for all the cases I could reproduce. I think that in each case, my change is no worse and sometimes better. In particular, the "working correctly" mode has no change from what I can tell, so I will omit those screenshots to spare the space in this PR. But I can add it if you would like.

## Firefox

### Image removed (Block gravatar.com with uBlock Origin)

Note that the box is collapsed in the "Before".

| Before                                                   | After                                                   |
| -------------------------------------------------------- | ------------------------------------------------------- |
| ![base-ublockorigin-personal-gravatar-firefox](https://github.com/user-attachments/assets/4e76b1f7-a2d7-473f-940e-4380b056e4f7) | ![fix-ublockorigin-personal-gravatar-firefox](https://github.com/user-attachments/assets/f6538f55-598e-4817-8ada-80d94e47b6f2) |
| ![base-ublockorigin-organization-gravatar-firefox](https://github.com/user-attachments/assets/c00ee72d-1533-491e-9e3e-18ff2be2582c) | ![fix-ublockorigin-organization-gravatar-firefox](https://github.com/user-attachments/assets/b2b93544-b308-4a42-afdc-b7e38c364cd6) |

### Broken image icon (Block gravatar.com with hosts file)

| Before                                                   | After                                                   |
| -------------------------------------------------------- | ------------------------------------------------------- |
| ![base-hostsfile-personal-gravatar-firefox](https://github.com/user-attachments/assets/50f887d6-e290-4834-9411-0fe4ee77a4ee) | ![fix-hostsfile-personal-gravatar-firefox](https://github.com/user-attachments/assets/5a3f784e-8f62-411a-99e1-f017ae3e48a0) |
| ![base-hostsfile-organization-gravatar-firefox](https://github.com/user-attachments/assets/d39b46d2-a0aa-47f6-8a72-5758346f48d5) | ![fix-hostsfile-organization-gravatar-firefox](https://github.com/user-attachments/assets/c397e62f-8b8d-47f2-82ee-79ca4852cc22) |

## Chromium

### Image removed (Block gravatar.com with uBlock Origin)

uBlock Origin was notably removed from the Chromium web store, so this does not apply here.

### Broken image icon (Block gravatar.com with hosts file)

| Before                                                   | After                                                   |
| -------------------------------------------------------- | ------------------------------------------------------- |
| ![base-hostsfile-personal-gravatar-chromium](https://github.com/user-attachments/assets/6b918412-c054-47a3-98e1-ea12544f7749) | ![fix-hostsfile-personal-gravatar-chromium](https://github.com/user-attachments/assets/61b02473-bd80-42bf-ac7c-d673d34b059f) |
| ![base-hostsfile-organization-gravatar-chromium](https://github.com/user-attachments/assets/48deb0ba-d601-4efa-8777-072e2a4a1453) | ![fix-hostsfile-organization-gravatar-chromium](https://github.com/user-attachments/assets/c6dcf84f-069c-438a-a78a-712875150050) |

---

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
